### PR TITLE
New async-safe interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,3 +2,10 @@
 # 0.1
 
 initial release
+
+# 0.2
+
+- Incompatible API change.
+
+- It is now safe to read TLS from asynchronous callbacks (e.g. memprof
+  callbacks).

--- a/src/thread_local_storage.mli
+++ b/src/thread_local_storage.mli
@@ -10,7 +10,9 @@ val create : unit -> 'a t
 
     Note: each TLS slot allocated consumes a word per thread, and it
     can never be deallocated. [create] should be called at toplevel to
-    produce constants, do not use it in a loop. *)
+    produce constants, do not use it in a loop.
+
+    @raise Failure if no more TLS slots can be allocated. *)
 
 val get : 'a t -> 'a
 (** [get x] returns the value previously stored in the TLS slot [x]

--- a/src/thread_local_storage.mli
+++ b/src/thread_local_storage.mli
@@ -1,19 +1,51 @@
 (** Thread local storage *)
 
-type 'a key
-(** A TLS key for values of type ['a]. This allows the
-  storage of a single value of type ['a] per thread. *)
+type 'a t
+(** A TLS slot for values of type ['a]. This allows the storage of a
+    single value of type ['a] per thread. *)
 
-val new_key : (unit -> 'a) -> 'a key
-(** Allocate a new, generative key.
-    When the key is used for the first time on a thread,
-    the function is called to produce it.
+val create : unit -> 'a t
+(** Allocate a new TLS slot. The TLS slot starts uninitialised on each
+    thread.
 
-    This should only ever be called at toplevel to produce
-    constants, do not use it in a loop. *)
+    Note: each TLS slot allocated consumes a word per thread, and it
+    can never be deallocated. [create] should be called at toplevel to
+    produce constants, do not use it in a loop. *)
 
-val get : 'a key -> 'a
-(** Get the value for the current thread. *)
+val get : 'a t -> 'a
+(** [get x] returns the value previously stored in the TLS slot [x]
+    for the current thread.
 
-val set : 'a key -> 'a -> unit
-(** Set the value for the current thread. *)
+    This function is safe to use from asynchronous callbacks without
+    risks of races.
+
+    @raise Failure if the TLS slot has not been initialised in the
+    current thread. *)
+
+val get_opt : 'a t -> 'a option
+(** [get_opt x] returns [Some v] where v is the value previously
+    stored in the TLS slot [x] for the current thread. It returns
+    [None] if the TLS slot has not been initialised in the current
+    thread.
+
+    This function is safe to use from asynchronous callbacks without
+    risks of races. *)
+
+val get_default : default:(unit -> 'a) -> 'a t -> 'a
+(** [get_default x ~default] returns the value previously stored in
+    the TLS slot [x] for the current thread. If the TLS slot has not
+    been initialised, [default ()] is called, and its result is
+    returned instead, after being stored in the TLS slot [x].
+
+    If the call to [default ()] raises an exception, then the TLS slot
+    remains uninitialised. If [default] is a function that always
+    raises, then this function is safe to use from asynchronous
+    callbacks without risks of races.
+
+    @raise Out_of_memory *)
+
+val set : 'a t -> 'a -> unit
+(** [set x v] stores [v] into the TLS slot [x] for the current
+    thread.
+
+    @raise Out_of_memory *)

--- a/test/thread_local_storage.ml
+++ b/test/thread_local_storage.ml
@@ -1,6 +1,6 @@
 module TLS = Thread_local_storage
 
-let k1 : int TLS.key = TLS.new_key (fun () -> 0)
+let k1 : int TLS.t = TLS.create ()
 
 let () =
   let n = 1_000_000 in
@@ -10,6 +10,7 @@ let () =
     Array.init 20 (fun t_idx ->
         Thread.create
           (fun () ->
+            TLS.set k1 0;
             for _i = 1 to n do
               let r = TLS.get k1 in
               TLS.set k1 (r + 1)
@@ -21,12 +22,14 @@ let () =
   Array.iter Thread.join threads;
   Array.iter (fun x -> assert (x = n)) values
 
-let k2 : int ref TLS.key = TLS.new_key (fun () -> ref 0)
-let k3 : int ref TLS.key = TLS.new_key (fun () -> ref 0)
+let k2 : int ref TLS.t = TLS.create ()
+let k3 : int ref TLS.t = TLS.create ()
 
 let () =
   let res = ref (0, 0) in
   let run () =
+    TLS.set k2 (ref 0);
+    TLS.set k3 (ref 0);
     for _i = 1 to 1000 do
       let r2 = TLS.get k2 in
       incr r2;


### PR DESCRIPTION
This PR changes the interface to allow usages where TLS is read from asynchronous callbacks. This fixes #2.

Since this is already an API change, I take the opportunity to follow naming conventions more closely.

Before I contribute some code, we should consider the question of licensing. Given that this is in the MIT license, there is the possibility of switching to a license which is more protective of contributions, e.g. LGPL. My preference goes for LGPL + linking exception. Which do you prefer? This is your repository, it's as you prefer.